### PR TITLE
Deinterlace renderer in non progressive input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         if (renderer_enabled)
         {
             std::cout << "Initializing live content rendering window" << std::endl;
-            if (!renderer.init(decoded_signal_info.width, decoded_signal_info.height, Deltacast::VideoViewer::InputFormat::bgr_444_8))
+            if (!renderer.init(decoded_signal_info.width, decoded_signal_info.height, Deltacast::VideoViewer::InputFormat::bgr_444_8, decoded_signal_info.progressive))
                 return -1;
     
             std::cout << std::endl;

--- a/src/rx_renderer.hpp
+++ b/src/rx_renderer.hpp
@@ -31,7 +31,7 @@ public:
     RxRenderer(RxRenderer&&) = delete;
     RxRenderer& operator=(RxRenderer&&) = delete;
 
-    bool init(int image_width, int image_height, Deltacast::VideoViewer::InputFormat input_format);
+    bool init(int image_width, int image_height, Deltacast::VideoViewer::InputFormat input_format, bool progressive);
     bool start(Deltacast::SharedResources& shared_resources);
     bool stop();
 
@@ -40,6 +40,8 @@ private:
     int _window_width;
     int _window_height;
     int _framerate_ms;
+    bool _progressive;
+    int _image_height;
 
     Deltacast::VideoViewer _monitor;
     std::thread _monitor_thread;


### PR DESCRIPTION
This should be also done in https://github.com/deltacasttv/videomaster-video-monitor/blob/df9237c26a7797505dccf19ff6a8a7b86aa37d9b/src/windowed_renderer.cpp#L72